### PR TITLE
feat(release-please): deprecated workflow updated to googleapis

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: auto-release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           # this assumes that you have created a personal access token
           # (PAT) and configured it as a GitHub action secret named


### PR DESCRIPTION
Release-Please action source change: `google` owner is deprecated -> `googleapis` is used now.

## Issue ticket number and link

## Type of change

Please check the relevant option.

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

-   [x] Tested the changed workflows in a repo

## Links to dependent PRs (if any)

Incase the current PR is dependent onto some other PR, please add the link to it.

## Checklist:

-   [ ] I have reviewed my code while raising this PR
-   [ ] I have added comments to my code, particularly in hard-to-understand areas
-   [ ] I have created a new README file named as `README-<name-of-the-workflow-file>.md` in case of new workflow addition,  or made corresponding changes to the documentation with respect to the changes.
-   [x] My changes generate no new warnings and errors
