### PR TITLE
Feature/caching

### DIFF
--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }} 
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }} 
       - name: Cache node modules
         id: cache-node-modules
         if: |
@@ -90,13 +90,13 @@ jobs:
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         continue-on-error: true
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package_manager }} list            
       - name: Install dependencies
         run: |
           ${{ inputs.package_manager }} install
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'

--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -89,6 +89,8 @@ jobs:
       - name: List the state of node modules
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         continue-on-error: true
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package_manager }} list            
       - name: Install dependencies
         run: |

--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -84,7 +84,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}-
+            ${{ runner.os }}-${{ inputs.package_manager }}--${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
       - name: Install dependencies
         if: |
           (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||

--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -2,6 +2,10 @@ name: Studiographene Mobile NodeJs CI
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        description: "A GitHub PersonalAccessToken used to access GitHub package regististy. NPM_TOKEN is also passed as Docker build --build-arg. If not defined default GITHUB_TOKEN is used."
+        required: false
     inputs:
       excluded_jobs:
         type: string
@@ -9,9 +13,6 @@ on:
       package_manager:
         type: string
         default: "npm"
-      npm_token:
-        type: string
-        default: ""
       lint_command:
         type: string
         default: "npm run lint"
@@ -72,7 +73,7 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }} 
       - name: Cache node modules
         id: cache-node-modules
         if: |
@@ -93,7 +94,7 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'

--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -84,12 +84,12 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}--${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+      - name: List the state of node modules
+        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        run: ${{ inputs.package_manager }} list            
       - name: Install dependencies
-        if: |
-          (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'yarn' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'pnpm' && steps.cache-node-modules.outputs.cache-hit != 'true')
         run: |
           ${{ inputs.package_manager }} install
         env:

--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -67,41 +67,33 @@ jobs:
         if: ${{ inputs.technology_based_scans_before_step_command != '' }}
         run: |
           ${{ inputs.technology_based_scans_before_step_command}}
-      - name: Install dependencies
-        run: |
-          ${{ inputs.package_manager }} install
-        env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Convert lockfile version > 2 in case of npm
         if: inputs.package_manager == 'npm'
         run: |
           ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache npm modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'npm'
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+      - name: Cache node modules
+        id: cache-node-modules
+        if: |
+          inputs.package_manager == 'npm' || 
+          inputs.package_manager == 'yarn' || 
+          inputs.package_manager == 'pnpm'  
+        uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.lock') }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
-      - name: Cache yarn modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'yarn'
-        with:
-          path: /usr/local/share/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'pnpm'
-        with:
-          path: /__w/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+            ${{ runner.os }}-${{ inputs.package_manager }}-
+      - name: Install dependencies
+        if: |
+          (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'yarn' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'pnpm' && steps.cache-node-modules.outputs.cache-hit != 'true')
+        run: |
+          ${{ inputs.package_manager }} install
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -131,6 +131,10 @@ jobs:
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+      - name: List the state of node modules
+        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        run: ${{ inputs.package_manager }} list 
       - name: Install dependencies
         run: |
           ${{ inputs.package_manager }} install
@@ -205,10 +209,6 @@ jobs:
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
-      - name: List the state of node modules
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        continue-on-error: true
-        run: ${{ inputs.package_manager }} list 
       - name: Install dependencies
         run: |
           ${{ inputs.package_manager }} install

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -239,9 +239,13 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Eslint scan
         if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'lint' )  }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           ${{ inputs.lint_command }}
       - name: Build project
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'build' )  }}
         run: |
           ${{ inputs.build_command }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -197,31 +197,23 @@ jobs:
         if: ${{ inputs.technology_based_scans_before_step_command != '' }}
         run: |
           ${{ inputs.technology_based_scans_before_step_command}}
-      - name: Cache npm modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'npm'
+      - name: Cache node modules
+        id: cache-modules
+        if: |
+          inputs.package_manager == 'npm' || 
+          inputs.package_manager == 'yarn' || 
+          inputs.package_manager == 'pnpm'  
+        uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.lock') }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
-      - name: Cache yarn modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'yarn'
-        with:
-          path: /usr/local/share/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'pnpm'
-        with:
-          path: /__w/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+            ${{ runner.os }}-${{ inputs.package_manager }}-
       - name: Install dependencies
+        if: |
+          (inputs.package_manager == 'npm' && steps.cache-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'yarn' && steps.cache-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'pnpm' && steps.cache-modules.outputs.cache-hit != 'true')
         run: |
           ${{ inputs.package_manager }} install
         env:

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -131,7 +131,6 @@ jobs:
           inputs.package_manager == 'pnpm'  
         run: |
           echo "cache-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"  
-          echo "cache-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_ENV"
       - name: Set cache restore key
         id: set-cache-restore-key
         if: |
@@ -140,7 +139,6 @@ jobs:
           inputs.package_manager == 'pnpm'  
         run: |
           echo "cache-restore-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"  
-          echo "cache-restore-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_ENV"          
       - name: Cache node modules
         id: cache-node-modules
         if: |
@@ -150,8 +148,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ env.cache-key }}
-          restore-keys: ${{ env.cache-restore-key }}
+          key: ${{ steps.set-cache-key.outputs.cache-key }} 
+          restore-keys: ${{ steps.set-cache-restore-key.outputs.cache-restore-key }}
       - name: List the state of node modules
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         continue-on-error: true
@@ -225,13 +223,10 @@ jobs:
           inputs.package_manager == 'yarn' || 
           inputs.package_manager == 'pnpm'  
         uses: actions/cache@v4
-        env:
-          cache-key: ${{ needs.caching.outputs.cache-key }}
-          cache-resotre-key: ${{ needs.caching.outputs.cache-restore-key }}
         with:
           path: node_modules
-          key: ${{ env.cache-key }}
-          restore-keys: ${{ env.cache-restore-key }}
+          key: ${{ needs.caching.outputs.cache-restore-key }}
+          restore-keys: ${{ needs.caching.outputs.cache-restore-key }}
       - name: Install dependencies
         run: |
           ${{ inputs.package_manager }} install

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -2,6 +2,10 @@ name: Studiographene NodeJs CI
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        description: "A GitHub PersonalAccessToken used to access GitHub package regististy. NPM_TOKEN is also passed as Docker build --build-arg. If not defined default GITHUB_TOKEN is used."
+        required: false
     inputs:
       excluded_jobs:
         type: string
@@ -9,9 +13,6 @@ on:
       package_manager:
         type: string
         default: "npm"
-      npm_token:
-        type: string
-        default: ""
       build_command:
         type: string
         default: "npm run build"
@@ -104,6 +105,9 @@ jobs:
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
     container:
       image: public.ecr.aws/studiographene/ci:node-20-alpine
+    outputs:
+      cache-key: ${{ steps.set-cache-key.outputs.cache-key }}  
+      cache-restore-key: ${{ steps.set-cache-restore-key.outputs.cache-restore-key }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,7 +122,25 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Set cache key
+        id: set-cache-key
+        if: |
+          inputs.package_manager == 'npm' || 
+          inputs.package_manager == 'yarn' || 
+          inputs.package_manager == 'pnpm'  
+        run: |
+          echo "cache-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"  
+          echo "cache-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_ENV"
+      - name: Set cache restore key
+        id: set-cache-restore-key
+        if: |
+          inputs.package_manager == 'npm' || 
+          inputs.package_manager == 'yarn' || 
+          inputs.package_manager == 'pnpm'  
+        run: |
+          echo "cache-restore-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"  
+          echo "cache-restore-key=${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}" >> "$GITHUB_ENV"          
       - name: Cache node modules
         id: cache-node-modules
         if: |
@@ -128,9 +150,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ env.cache-key }}
+          restore-keys: ${{ env.cache-restore-key }}
       - name: List the state of node modules
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         continue-on-error: true
@@ -139,7 +160,7 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}           
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'
@@ -176,6 +197,7 @@ jobs:
       semgrep_options: ${{ inputs.semgrep_options }}
 
   technology_based_scans:
+    needs: caching
     name: technology_based_scans
     runs-on: ubuntu-latest
     permissions:
@@ -184,7 +206,6 @@ jobs:
       discussions: write
       pull-requests: write
       security-events: write
-    needs: caching
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
     container:
       image: public.ecr.aws/studiographene/ci:node-20-buster-slim-v1
@@ -204,16 +225,18 @@ jobs:
           inputs.package_manager == 'yarn' || 
           inputs.package_manager == 'pnpm'  
         uses: actions/cache@v4
+        env:
+          cache-key: ${{ needs.caching.outputs.cache-key }}
+          cache-resotre-key: ${{ needs.caching.outputs.cache-restore-key }}
         with:
           path: node_modules
-          key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ env.cache-key }}
+          restore-keys: ${{ env.cache-restore-key }}
       - name: Install dependencies
         run: |
           ${{ inputs.package_manager }} install
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Eslint scan
         if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'lint' )  }}
         run: |

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Set cache key
         id: set-cache-key
         if: |
@@ -154,13 +154,13 @@ jobs:
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         continue-on-error: true
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package_manager }} list 
       - name: Install dependencies
         run: |
           ${{ inputs.package_manager }} install
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'
@@ -233,16 +233,16 @@ jobs:
         run: |
           ${{ inputs.package_manager }} install
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Eslint scan
         if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'lint' )  }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           ${{ inputs.lint_command }}
       - name: Build project
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'build' )  }}
         run: |
           ${{ inputs.build_command }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -113,41 +113,33 @@ jobs:
         if: ${{ inputs.caching_before_step_command != '' }}
         run: |
           ${{ inputs.caching_before_step_command}}
-      - name: Install dependencies
-        run: |
-          ${{ inputs.package_manager }} install
-        env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Convert lockfile version > 2 in case of npm
         if: inputs.package_manager == 'npm'
         run: |
           ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache npm modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'npm'
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+      - name: Cache node modules
+        id: cache-modules
+        if: |
+          inputs.package_manager == 'npm' || 
+          inputs.package_manager == 'yarn' || 
+          inputs.package_manager == 'pnpm'  
+        uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.lock') }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
-      - name: Cache yarn modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'yarn'
-        with:
-          path: /usr/local/share/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        if: inputs.package_manager == 'pnpm'
-        with:
-          path: /__w/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+            ${{ runner.os }}-${{ inputs.package_manager }}-
+      - name: Install dependencies
+        if: |
+          (inputs.package_manager == 'npm' && steps.cache-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'yarn' && steps.cache-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'pnpm' && steps.cache-modules.outputs.cache-hit != 'true')
+        run: |
+          ${{ inputs.package_manager }} install
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}           
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -153,6 +153,8 @@ jobs:
       - name: List the state of node modules
         if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         continue-on-error: true
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: ${{ inputs.package_manager }} list 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -130,12 +130,8 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}--${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
       - name: Install dependencies
-        if: |
-          (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'yarn' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'pnpm' && steps.cache-node-modules.outputs.cache-hit != 'true')
         run: |
           ${{ inputs.package_manager }} install
         env:
@@ -208,12 +204,12 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}--${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+      - name: List the state of node modules
+        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        run: ${{ inputs.package_manager }} list 
       - name: Install dependencies
-        if: |
-          (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'yarn' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'pnpm' && steps.cache-node-modules.outputs.cache-hit != 'true')
         run: |
           ${{ inputs.package_manager }} install
         env:

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -130,7 +130,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}-
+            ${{ runner.os }}-${{ inputs.package_manager }}--${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
       - name: Install dependencies
         if: |
           (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
@@ -208,7 +208,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ inputs.package_manager }}-${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.package_manager }}-
+            ${{ runner.os }}-${{ inputs.package_manager }}--${{ hashFiles('**/package-lock.json', '**/package.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
       - name: Install dependencies
         if: |
           (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
       - name: Cache node modules
-        id: cache-modules
+        id: cache-node-modules
         if: |
           inputs.package_manager == 'npm' || 
           inputs.package_manager == 'yarn' || 
@@ -133,9 +133,9 @@ jobs:
             ${{ runner.os }}-${{ inputs.package_manager }}-
       - name: Install dependencies
         if: |
-          (inputs.package_manager == 'npm' && steps.cache-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'yarn' && steps.cache-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'pnpm' && steps.cache-modules.outputs.cache-hit != 'true')
+          (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'yarn' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'pnpm' && steps.cache-node-modules.outputs.cache-hit != 'true')
         run: |
           ${{ inputs.package_manager }} install
         env:
@@ -198,7 +198,7 @@ jobs:
         run: |
           ${{ inputs.technology_based_scans_before_step_command}}
       - name: Cache node modules
-        id: cache-modules
+        id: cache-node-modules
         if: |
           inputs.package_manager == 'npm' || 
           inputs.package_manager == 'yarn' || 
@@ -211,9 +211,9 @@ jobs:
             ${{ runner.os }}-${{ inputs.package_manager }}-
       - name: Install dependencies
         if: |
-          (inputs.package_manager == 'npm' && steps.cache-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'yarn' && steps.cache-modules.outputs.cache-hit != 'true') ||
-          (inputs.package_manager == 'pnpm' && steps.cache-modules.outputs.cache-hit != 'true')
+          (inputs.package_manager == 'npm' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'yarn' && steps.cache-node-modules.outputs.cache-hit != 'true') ||
+          (inputs.package_manager == 'pnpm' && steps.cache-node-modules.outputs.cache-hit != 'true')
         run: |
           ${{ inputs.package_manager }} install
         env:

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -51,7 +51,7 @@ jobs:
     container:
       image: ${{ inputs.action_runner_container_image }}
     env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Before Step
         if: ${{ inputs.before_step_command != '' }}

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        description: "A GitHub PersonalAccessToken used to access NPM package regististy. NPM_TOKEN is passed as Docker build --build-arg. If not defined GITHUB_TOKEN is used."
+        description:"A GitHub PersonalAccessToken used to access GitHub package regististy. NPM_TOKEN is also passed as Docker build --build-arg. If not defined default GITHUB_TOKEN is used."
         required: false
 
     inputs:
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.action_runner_container_image }}
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN && secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Before Step
         if: ${{ inputs.before_step_command != '' }}

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        description:"A GitHub PersonalAccessToken used to access GitHub package regististy. NPM_TOKEN is also passed as Docker build --build-arg. If not defined default GITHUB_TOKEN is used."
+        description: "A GitHub PersonalAccessToken used to access GitHub package regististy. NPM_TOKEN is also passed as Docker build --build-arg. If not defined default GITHUB_TOKEN is used."
         required: false
 
     inputs:

--- a/README-nodejs-ci.md
+++ b/README-nodejs-ci.md
@@ -14,7 +14,6 @@ CI scans workflow for NodeJS code.
 | dev_test_branch | A string of comma separated branches that you want to run developer tests on. (support list of branches. Ex  `dev,qa` or `uat`) | no | `'qa'` |
 | coverage_summary_path | Path to the coverage summary JSON file generated from developer's test | no | `./coverage/coverage-summary.json` |
 | junitxml_path  | Path to the JUnit XML report file generated from developer's test | no | `./coverage/report.xml`  |                                                                             | no       | `npm`           |
-| npm_token                                  | NPM token                                                                   | no       |                 |
 | build_command                              | build command for the project                                               | no       | `npm run build` |
 | docker_build_command                       | Docker build command                                                        | no       |                 |
 | docker_build_image_id                      | Docker image ID as mentioned in docker_build_command                        | no       | `local:latest`  |
@@ -32,6 +31,12 @@ CI scans workflow for NodeJS code.
 | pr_agent_after_step_command                | Optional commands to pass after Codium PR agent job steps execution         | no       |                 |
 | container_scan_before_step_command         | Command to execute at the start of the container scan                       | no       |                 |
 | container_scan_after_step_command          | Command to execute at the end of the container scan                         | no       |                 |
+
+# Workflow Secrets
+
+| Name                                       | Description                                                                 | Required | Default         |
+| ------------------------------------------ | --------------------------------------------------------------------------- | -------- | --------------- |
+| NPM_TOKEN                                  | A GitHub PersonalAccessToken used to access GitHub package regististy. NPM_TOKEN is also passed as Docker build --build-arg. If not defined default GITHUB_TOKEN is used. `Set this key and GitHub PAT with read:packages permission in GitHub Actions Secrets.`                                                                    | To authenicate SG's private NPM packages hosted on Github Package Registry     | GITHUB_TOKEN |
 
 # Action variables
 


### PR DESCRIPTION
updated caching job to cache node_modules.
Making cache key and restore key is not possible to make as global env as hashFiles and runner.os is not supported at that level.

This config will cache node_modules and save it in compressed size. The uploaded size of node_modules as cache is around 1/9 th of the actual node modules.