### PR TITLE
fix(lock-file): fixed the convert lockfile step

### DIFF
--- a/.github/workflows/mobile-nodejs-ci.yml
+++ b/.github/workflows/mobile-nodejs-ci.yml
@@ -68,12 +68,6 @@ jobs:
         if: ${{ inputs.technology_based_scans_before_step_command != '' }}
         run: |
           ${{ inputs.technology_based_scans_before_step_command}}
-      - name: Convert lockfile version > 2 in case of npm
-        if: inputs.package_manager == 'npm'
-        run: |
-          ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }} 
       - name: Cache node modules
         id: cache-node-modules
         if: |
@@ -97,6 +91,12 @@ jobs:
           ${{ inputs.package_manager }} install
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Convert lockfile version > 2 in case of npm
+        if: inputs.package_manager == 'npm'
+        run: |
+          ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }} 
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -106,13 +106,7 @@ jobs:
       - name: before step
         if: ${{ inputs.caching_before_step_command != '' }}
         run: |
-          ${{ inputs.caching_before_step_command}}
-      - name: Convert lockfile version > 2 in case of npm
-        if: inputs.package_manager == 'npm'
-        run: |
-          ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}          
+          ${{ inputs.caching_before_step_command}}          
       - name: Set cache key
         id: set-cache-key
         if: |
@@ -151,6 +145,12 @@ jobs:
           ${{ inputs.package_manager }} install
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Convert lockfile version > 2 in case of npm
+        if: inputs.package_manager == 'npm'
+        run: |
+          ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}          
       - name: Upload package-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'


### PR DESCRIPTION

### What:

> Fix

Rearranged the convert lockfile step after npm install step to generate package-lock.json in case it is not available from code.

#### Why:

Convert lock file step in case of npm errored for cache modules job if package-lock.json is not readily available in code.
