### PR TITLE
Feat(ENB-83)!: split step to jobs, monorepo multi containers scan support, dependency scan moderate failure

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -193,7 +193,7 @@ jobs:
         run: ${{ inputs.package_manager }} list
       - name: Install dependencies
         run: |
-          ${{ inputs.package_manager != '' && inputs.package_install_command || inputs.package_manager install }}
+          ${{ inputs.package_manager }} != '' && ${{ inputs.package_install_command }} || ${{ inputs.package_manager }} install
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Convert package_lockFile version > 2 in case of npm

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -26,7 +26,7 @@ on:
         description: "Package install command to use instead of the default command."
         type: string
         required: false
-        default: "npm"
+        default: ""
       build_command:
         type: string
         default: "npm run build"
@@ -381,10 +381,10 @@ jobs:
       docker_build_image_id: ${{ inputs.docker_build_image_id }}
       container_scanners: ${{ inputs.container_scanners }}
       container_scan_skip_dirs: ${{ inputs.container_scan_skip_dirs }}
-      before_step_command: ${{ inputs.container_scan_before_step_command }}
-      after_step_command: ${{ inputs.container_scan_after_step_command}}
       is_monorepo_with_multi_dockerfile: ${{ inputs.is_monorepo_with_multi_dockerfile}}
       dockerfile_paths: ${{ inputs.dockerfile_paths}}
+      before_step_command: ${{ inputs.container_scan_before_step_command }}
+      after_step_command: ${{ inputs.container_scan_after_step_command}}
 
   pr_agent:
     name: pr_agent

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -193,7 +193,7 @@ jobs:
         run: ${{ inputs.package_manager }} list
       - name: Install dependencies
         run: |
-          ${{ inputs.package_manager }} != '' && ${{ inputs.package_install_command }} || ${{ inputs.package_manager }} install
+          ${{ inputs.package_install_command }} != '' && ${{ inputs.package_install_command }} || ${{ inputs.package_manager }} install
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Convert package_lockFile version > 2 in case of npm

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -300,7 +300,7 @@ jobs:
       security-events: write
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
     container:
-      image: public.ecr.aws/studiographene/ci:node-22-buster-slim-v5
+      image: public.ecr.aws/studiographene/ci:node-20-buster-slim-v5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -25,6 +25,21 @@ on:
         type: string
         required: false
         default: "ubuntu-latest"
+      linting_job_runner:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+      build_test_job_runner:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+      container_scan_job_runner:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        required: false
+        default: "ubuntu-latest"
       PULSE_URL:
         type: string
         default: "https://a0lrn1xwl4.execute-api.eu-west-1.amazonaws.com"
@@ -263,7 +278,7 @@ jobs:
   eslint:
     needs: caching
     name: eslint_scan
-    runs-on: ${{ inputs.job_runner }}
+    runs-on: ${{ inputs.linting_job_runner }}
     permissions:
       contents: read
       issues: write
@@ -314,7 +329,7 @@ jobs:
   build_test:
     needs: caching
     name: build_test
-    runs-on: ${{ inputs.job_runner }}
+    runs-on: ${{ inputs.build_test_job_runner }}
     permissions:
       contents: read
       issues: write
@@ -444,6 +459,7 @@ jobs:
     uses: studiographene/github-action-workflows/.github/workflows/trivy-container-scan.yml@feat/ENB-83/split-jobs
     secrets: inherit
     with:
+      job_runner: ${{ inputs.container_scan_job_runner }}
       docker_build_command: ${{ inputs.docker_build_command }}
       docker_build_image_id: ${{ inputs.docker_build_image_id }}
       container_scanners: ${{ inputs.container_scanners }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -70,11 +70,6 @@ on:
         type: string
         required: false
         default: dev
-      is_monorepo_with_multi_dockerfile:
-        description: "For container scan. Whether it is a monorepo with Dockerfile in differnet directories. If `true` repo will be searched for all the Dockerfile and scan performed on each. To scan only selected Docker file use input `dockerfile_paths`"
-        type: boolean
-        required: false
-        default: false
       dockerfile_paths:
         description: "For container scan. Set of separated Dockerfile paths. Useful when you want scan Dockerfile in selected directories. Example: [./apps/users/Dockerfile, ./apps/account/Dockerfile]"
         type: string
@@ -464,7 +459,6 @@ jobs:
       docker_build_image_id: ${{ inputs.docker_build_image_id }}
       container_scanners: ${{ inputs.container_scanners }}
       container_scan_skip_dirs: ${{ inputs.container_scan_skip_dirs }}
-      is_monorepo_with_multi_dockerfile: ${{ inputs.is_monorepo_with_multi_dockerfile}}
       dockerfile_paths: ${{ inputs.dockerfile_paths}}
       before_step_command: ${{ inputs.container_scan_before_step_command }}
       after_step_command: ${{ inputs.container_scan_after_step_command}}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -22,6 +22,11 @@ on:
       package_manager:
         type: string
         default: "npm"
+      package_install_command:
+        description: "Package install command to use instead of the default command."
+        type: string
+        required: false
+        default: "npm"
       build_command:
         type: string
         default: "npm run build"
@@ -188,32 +193,32 @@ jobs:
         run: ${{ inputs.package_manager }} list
       - name: Install dependencies
         run: |
-          ${{ inputs.package_manager }} install
+          ${{ inputs.package_manager != '' && inputs.package_install_command || inputs.package_manager install }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Convert lockfile version > 2 in case of npm
+      - name: Convert package_lockFile version > 2 in case of npm
         if: inputs.package_manager == 'npm'
         run: |
-          ${{ inputs.package_manager }} install --lockfile-version 2 --package-lock-only
+          ${{ inputs.package_manager }} install --package_lockFile-version 2 --package-lock-only
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Upload package-lock artifact
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'npm'
         with:
-          name: lockFile
+          name: package_lockFile
           path: package-lock.json
       - name: Upload yarn-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'yarn'
         with:
-          name: lockFile
+          name: package_lockFile
           path: yarn.lock
       - name: Upload pnpm-lock
         uses: actions/upload-artifact@v4
         if: inputs.package_manager == 'pnpm'
         with:
-          name: lockFile
+          name: package_lockFile
           path: pnpm-lock.yaml
       - name: after step
         if: ${{ inputs.caching_after_step_command != '' }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -378,15 +378,6 @@ jobs:
       before_step_command: ${{ inputs.container_scan_before_step_command }}
       after_step_command: ${{ inputs.container_scan_after_step_command}}
 
-  pr_agent:
-    name: pr_agent
-    if: ${{ !contains( inputs.excluded_jobs, 'pr_agent' ) && !(contains(fromJSON('["dependabot[bot]", "github-actions[bot]"]'), github.actor)) && !(github.event.pull_request.merged == true  || github.event_name == 'issue_comment') }}
-    uses: studiographene/github-action-workflows/.github/workflows/codium-pr-agent.yml@master
-    secrets: inherit
-    with:
-      before_step_command: ${{ inputs.pr_agent_before_step_command }}
-      after_step_command: ${{ inputs.pr_agent_after_step_command}}
-
   pulse_work_break_down:
     name: pulse-work-break-down
     if: ${{ github.event.pull_request.merged == true && contains(inputs.dev_test_branch, github.event.pull_request.base.ref) }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -261,7 +261,7 @@ jobs:
     name: security_scans
     needs: caching
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !(github.event.pull_request.merged == true) }}
-    uses: studiographene/github-action-workflows/.github/workflows/security-scans.yml@feat/ENB-83/split-jobs
+    uses: studiographene/github-action-workflows/.github/workflows/security-scans.yml@master
     secrets: inherit
     with:
       security_scan_before_step_command: ${{ inputs.security_scan_before_step_command }}
@@ -450,7 +450,7 @@ jobs:
   container_scan:
     name: container_scan
     if: ${{ !contains( inputs.excluded_jobs, 'docker' ) && !contains( inputs.excluded_jobs, 'container_scan' ) && !(contains(fromJSON('["dependabot[bot]", "github-actions[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !(github.event.pull_request.merged == true) }}
-    uses: studiographene/github-action-workflows/.github/workflows/trivy-container-scan.yml@feat/ENB-83/split-jobs
+    uses: studiographene/github-action-workflows/.github/workflows/trivy-container-scan.yml@master
     secrets: inherit
     with:
       job_runner: ${{ inputs.container_scan_job_runner }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -193,7 +193,7 @@ jobs:
         run: ${{ inputs.package_manager }} list
       - name: Install dependencies
         run: |
-          ${{ inputs.package_install_command }} == '' && ${{ inputs.package_manager }} install || ${{ inputs.package_install_command }}
+          ${{ inputs.package_install_command != '' && inputs.package_install_command || format('{0} install', inputs.package_manager) }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Convert package_lockFile version > 2 in case of npm

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -10,7 +10,17 @@ on:
         description: "A secret key to generate HMAC for Pulse API. This is used to send test coverage report to Pulse."
         required: false
     inputs:
-      job_runtime:
+      job_runner:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+      security_scans_job_runner:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+      caching_job_runner:
         description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
         type: string
         required: false
@@ -152,7 +162,7 @@ on:
 jobs:
   caching:
     name: cache_module
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.caching_job_runner }}
     permissions:
       contents: read
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
@@ -248,12 +258,12 @@ jobs:
       security_scan_after_step_command: ${{ inputs.security_scan_after_step_command }}
       excluded_jobs: ${{ inputs.excluded_jobs }}
       semgrep_options: ${{ inputs.semgrep_options }}
-      job_runtime: ${{ inputs.job_runtime }}
+      job_runner: ${{ inputs.security_scans_job_runner }}
 
   eslint:
     needs: caching
     name: eslint_scan
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write
@@ -304,7 +314,7 @@ jobs:
   build_test:
     needs: caching
     name: build_test
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write
@@ -355,7 +365,7 @@ jobs:
   developer_tests:
     needs: caching
     name: developer_tests
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -13,7 +13,7 @@ on:
       job_runtime:
         description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
         type: string
-        request: false
+        required: false
         default: "ubuntu-latest"
       PULSE_URL:
         type: string

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -125,7 +125,6 @@ on:
         description: "Command to execute at the end of the Lint scan"
         type: string
         default: ""
-
       send_dev_test_coverage_report_to_pulse:
         description: "A boolean value to enable sending test coverage report to Pulse"
         type: boolean
@@ -255,6 +254,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+      - name: lint scan before step
+        if: ${{ inputs.technology_based_scans_before_step_command != '' || inputs.lint_scan_before_step_command != '' }}
+        run: |
+          ${{ inputs.technology_based_scans_before_step_command}}
+          ${{ inputs.lint_scan_before_step_command }}
       - name: Cache node modules
         id: cache-node-modules
         if: |
@@ -271,11 +275,6 @@ jobs:
           ${{ inputs.package_manager }} install
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: lint scan before step
-        if: ${{ inputs.technology_based_scans_before_step_command != '' || inputs.lint_scan_before_step_command != '' }}
-        run: |
-          ${{ inputs.technology_based_scans_before_step_command}}
-          ${{ inputs.lint_scan_before_step_command }}
       - name: linting
         if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'lint' ) && !(github.event.pull_request.merged == true ) }}
         env:
@@ -311,13 +310,6 @@ jobs:
         run: |
           ${{ inputs.technology_based_scans_before_step_command}}
           ${{ inputs.developer_tests_before_step_command }}
-
-      # - name: Build project
-      #   env:
-      #     NPM_TOKEN: ${{ (secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN) && !(github.event.pull_request.merged == true ) }}
-      #   if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'build' ) && !(github.event.pull_request.merged == true )  }}
-      #   run: |
-      #     ${{ inputs.build_command }}
 
       - name: Tests
         id: developer_tests

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -382,7 +382,7 @@ jobs:
       discussions: write
       pull-requests: write
       security-events: write
-    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
+    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && inputs.run_dev_test && !contains( inputs.excluded_jobs, 'developer_tests' ) && contains(inputs.dev_test_branch, github.event.pull_request.base.ref) }}
     container:
       image: public.ecr.aws/studiographene/ci:node-20-buster-slim-v5
     steps:
@@ -398,7 +398,6 @@ jobs:
 
       - name: Tests
         id: developer_tests
-        if: ${{ always() && inputs.run_dev_test && contains(inputs.dev_test_branch, github.event.pull_request.base.ref) }}
         run: |
           ${{ inputs.package_manager }} run test
       - name: Test Coverage Threshold Check

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -10,6 +10,11 @@ on:
         description: "A secret key to generate HMAC for Pulse API. This is used to send test coverage report to Pulse."
         required: false
     inputs:
+      job_runtime:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        request: false
+        default: "ubuntu-latest"
       PULSE_URL:
         type: string
         default: "https://a0lrn1xwl4.execute-api.eu-west-1.amazonaws.com"
@@ -117,6 +122,14 @@ on:
         description: "Command to execute at the end of the Developer tests"
         type: string
         default: ""
+      build_test_before_step_command:
+        description: "Command to execute at the start of the Build Test Job"
+        type: string
+        default: ""
+      build_test_after_step_command:
+        description: "Command to execute at the end of the Build Test Job"
+        type: string
+        default: ""
       lint_scan_before_step_command:
         description: "Command to execute at the start of the Lint scan"
         type: string
@@ -139,7 +152,7 @@ on:
 jobs:
   caching:
     name: cache_module
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
@@ -235,11 +248,12 @@ jobs:
       security_scan_after_step_command: ${{ inputs.security_scan_after_step_command }}
       excluded_jobs: ${{ inputs.excluded_jobs }}
       semgrep_options: ${{ inputs.semgrep_options }}
+      job_runtime: ${{ inputs.job_runtime }}
 
   eslint:
     needs: caching
     name: eslint_scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
       issues: write
@@ -286,11 +300,62 @@ jobs:
         run: |
           ${{ inputs.technology_based_scans_before_step_command}}
           ${{ inputs.lint_scan_after_step_command }}
+  
+  build_test:
+    needs: caching
+    name: build_test
+    runs-on: ${{ inputs.job_runtime }}
+    permissions:
+      contents: read
+      issues: write
+      discussions: write
+      pull-requests: write
+      security-events: write
+    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
+    container:
+      image: public.ecr.aws/studiographene/ci:node-22-alpine
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}                
+      - name: Build Test before step
+        if: ${{ inputs.technology_based_scans_before_step_command != '' || inputs.build_test_before_step_command != '' }}
+        run: |
+          ${{ inputs.technology_based_scans_before_step_command}}
+          ${{ inputs.build_test_before_step_command }}
+      - name: Restore Cached node modules
+        id: restore_cache_node_modules
+        if: |
+          inputs.package_manager == 'npm' || 
+          inputs.package_manager == 'yarn' || 
+          inputs.package_manager == 'pnpm'  
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ needs.caching.outputs.cache-restore-key }}
+          restore-keys: ${{ needs.caching.outputs.cache-restore-key }}
+      - name: Install dependencies
+        run: |
+          ${{ inputs.package_manager }} install
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Build project
+        env:
+          NPM_TOKEN: ${{ (secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN) && !(github.event.pull_request.merged == true ) }}
+        if: ${{ !cancelled() && !contains( inputs.excluded_jobs, 'build' ) && !(github.event.pull_request.merged == true )  }}
+        run: |
+          ${{ inputs.build_command }}
+      - name: Build Test after step
+        if: ${{ inputs.technology_based_scans_before_step_command != '' || inputs.build_test_after_step_command != '' }}
+        run: |
+          ${{ inputs.technology_based_scans_before_step_command}}
+          ${{ inputs.build_test_after_step_command }}
 
   developer_tests:
     needs: caching
     name: developer_tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -182,7 +182,7 @@ jobs:
       contents: read
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
     container:
-      image: public.ecr.aws/studiographene/ci:node-22-alpine
+      image: public.ecr.aws/studiographene/ci:node-20-buster-slim-v5 #public.ecr.aws/studiographene/ci:node-22-alpine
     outputs:
       cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
       cache-restore-key: ${{ steps.set-cache-restore-key.outputs.cache-restore-key }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -193,7 +193,7 @@ jobs:
         run: ${{ inputs.package_manager }} list
       - name: Install dependencies
         run: |
-          ${{ inputs.package_install_command }} != '' && ${{ inputs.package_install_command }} || ${{ inputs.package_manager }} install
+          ${{ inputs.package_install_command }} == '' && ${{ inputs.package_manager }} install || ${{ inputs.package_install_command }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Convert package_lockFile version > 2 in case of npm

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -182,7 +182,7 @@ jobs:
       contents: read
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
     container:
-      image: public.ecr.aws/studiographene/ci:node-20-buster-slim-v5 #public.ecr.aws/studiographene/ci:node-22-alpine
+      image: public.ecr.aws/studiographene/ci:node-22-alpine
     outputs:
       cache-key: ${{ steps.set-cache-key.outputs.cache-key }}
       cache-restore-key: ${{ steps.set-cache-restore-key.outputs.cache-restore-key }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -331,7 +331,7 @@ jobs:
       discussions: write
       pull-requests: write
       security-events: write
-    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
+    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !contains( inputs.excluded_jobs, 'build_test' )  }}
     container:
       image: public.ecr.aws/studiographene/ci:node-22-alpine
     steps:

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -6,11 +6,6 @@ on:
       excluded_jobs:
         type: string
         default: ""
-      is_monorepo_with_multi_dockerfile:
-        description: "For container scan. Whether it is a monorepo with Dockerfile in differnet directories. If `true` repo will be searched for all the Dockerfile and scan performed on each. To scan only selected Docker file use input `dockerfile_paths`"
-        type: boolean
-        required: false
-        default: false
       dockerfile_paths:
         description: "For container scan. Set of separated Dockerfile paths. Useful when you want scan Dockerfile in selected directories. Example: [./apps/users/Dockerfile, ./apps/account/Dockerfile]"
         type: string
@@ -71,7 +66,6 @@ jobs:
       docker_build_image_id: ${{ inputs.docker_build_image_id }}
       container_scanners: ${{ inputs.container_scanners }}
       container_scan_skip_dirs: ${{ inputs.container_scan_skip_dirs }}
-      is_monorepo_with_multi_dockerfile: ${{ inputs.is_monorepo_with_multi_dockerfile}}
       dockerfile_paths: ${{ inputs.dockerfile_paths}}
       before_step_command: ${{ inputs.container_scan_before_step_command }}
       after_step_command: ${{ inputs.container_scan_after_step_command}}

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -6,6 +6,16 @@ on:
       excluded_jobs:
         type: string
         default: ""
+      is_monorepo_with_multi_dockerfile:
+        description: "For container scan. Whether it is a monorepo with Dockerfile in differnet directories. If `true` repo will be searched for all the Dockerfile and scan performed on each. To scan only selected Docker file use input `dockerfile_paths`"
+        type: boolean
+        required: false
+        default: false
+      dockerfile_paths:
+        description: "For container scan. Set of separated Dockerfile paths. Useful when you want scan Dockerfile in selected directories. Example: [./apps/users/Dockerfile, ./apps/account/Dockerfile]"
+        type: string
+        required: false
+        default: ""
       docker_build_command:
         type: string
         required: false
@@ -62,13 +72,15 @@ jobs:
   container_scan:
     name: container_scan
     if: ${{ !contains( inputs.excluded_jobs, 'docker' ) && !contains( inputs.excluded_jobs, 'container_scan' ) && !(contains(fromJSON('["dependabot[bot]", "github-actions[bot]"]'), github.actor)) }}
-    uses: studiographene/github-action-workflows/.github/workflows/trivy-container-scan.yml@master
+    uses: studiographene/github-action-workflows/.github/workflows/trivy-container-scan.yml@feat/ENB-83/split-jobs
     secrets: inherit
     with:
       docker_build_command: ${{ inputs.docker_build_command }}
       docker_build_image_id: ${{ inputs.docker_build_image_id }}
       container_scanners: ${{ inputs.container_scanners }}
       container_scan_skip_dirs: ${{ inputs.container_scan_skip_dirs }}
+      is_monorepo_with_multi_dockerfile: ${{ inputs.is_monorepo_with_multi_dockerfile}}
+      dockerfile_paths: ${{ inputs.dockerfile_paths}}
       before_step_command: ${{ inputs.container_scan_before_step_command }}
       after_step_command: ${{ inputs.container_scan_after_step_command}}
 

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -60,14 +60,6 @@ on:
         default: ""
 
 jobs:
-  pr_agent:
-    name: pr_agent
-    if: ${{ !contains( inputs.excluded_jobs, 'pr_agent' ) && !(contains(fromJSON('["dependabot[bot]", "github-actions[bot]"]'), github.actor)) }}
-    uses: studiographene/github-action-workflows/.github/workflows/codium-pr-agent.yml@master
-    secrets: inherit
-    with:
-      before_step_command: ${{ inputs.pr_agent_before_step_command }}
-      after_step_command: ${{ inputs.pr_agent_after_step_command}}
 
   container_scan:
     name: container_scan

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,7 +265,7 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          if [ "$OSV_EXIT_CODE" == 1 ]; then
+          if [ "$OSV_EXIT_CODE" = "1" ]; then
             echo "Executing IF statement (vulnerabilities found)"
             SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 
                 | select(.groups != null) 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -134,11 +134,11 @@ jobs:
             echo "Files do not exist"
             echo "SKIP_DOWNLOAD_LOCKFILE=false" >> $GITHUB_OUTPUT
           fi
-      - name: Download LockFile Artifact
+      - name: Download package_lockFile Artifact
         if: ${{ !cancelled() && steps.check_files.outputs.SKIP_DOWNLOAD_LOCKFILE != 'true' }}
         uses: actions/download-artifact@v4
         with:
-          name: lockFile
+          name: package_lockFile
           path: .
       - name: Generate SBOM using CycloneDX
         if: always ()

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,10 +271,7 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? 
-              | select(.groups != null) 
-              | .groups[]?.max_severity 
-              | tonumber] as $scores 
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores 
               | [
                   ($scores | map(select(. < 4)) | length),
                   ($scores | map(select(. >= 4 and . <= 6)) | length),

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -266,9 +266,9 @@ jobs:
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           REPORT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
-          if [ "$REPORT_RESULT_LENGTH" == "0" ]; then
+          if [ "$REPORT_RESULT_LENGTH" = "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"
-            SEVERITY_COUNTS="0 0 0"
+            SEVERITY_COUNTS="'0' '0' '0'"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
             SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -275,29 +275,36 @@ jobs:
                 ] 
               | @sh
             ' osv_raw_report.json)
-            OSV_SEVERITY_LOW=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
-            OSV_SEVERITY_MEDIUM=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)
-            OSV_SEVERITY_HIGH=$(echo $SEVERITY_COUNTS | cut -d' ' -f3)
-            echo "OSV_SEVERITY_LOW=$low" >> $GITHUB_OUTPUT
-            echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
-            echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT
+            OSV_SEVERITY_LOW_COUNT=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
+            OSV_SEVERITY_MEDIUM_COUNT=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)
+            OSV_SEVERITY_HIGH_COUNT=$(echo $SEVERITY_COUNTS | cut -d' ' -f3)
+            echo "OSV_SEVERITY_LOW_COUNT=$low" >> $GITHUB_OUTPUT
+            echo "OSV_SEVERITY_MEDIUM_COUNT=$medium" >> $GITHUB_OUTPUT
+            echo "OSV_SEVERITY_HIGH_COUNT=$high" >> $GITHUB_OUTPUT
             echo "### The following vulnerabilities have been detected in the packages" >> osv_report.md
-            echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW" >> osv_report.md
-            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM" >> osv_report.md
-            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH" >> osv_report.md
-            echo "### ${OSV_SEVERITY_HIGH} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
-            echo "LOW SEVERITY COUNT: $OSV_SEVERITY_LOW"
-            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM"
-            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH"
+            echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT" >> osv_report.md
+            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT" >> osv_report.md
+            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT" >> osv_report.md
+            echo "### ${OSV_SEVERITY_HIGH_COUNT} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
+            echo "LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT"
+            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT"
+            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT"
             cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md
             cat osv_raw_report.md >> osv_report.md
           fi
-          echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW"
-          echo "> MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM"
-          echo "> HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH"
+          echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT"
+          echo "> MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT"
+          echo "> HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT"
           cat osv_report.md
+          if [ $OSV_SEVERITY_HIGH_COUNT > 0 ]; then
+            echo "::error::HIGH Severity Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
+            exit 1
+          elif [ $OSV_SEVERITY_MEDIUM_COUNT > 0 ]; then
+            echo "::warning::MEDIUM or LOW Severity Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
+            exit 0
+          fi
       - name: Comment Dependency scan report on PR
         if: ${{ !cancelled() || contains('success,failure', steps.dependency_scan.outcome) }}
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,11 +265,11 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          REPORT_RESULT_LENGTH=$(jq -r '.results[].package | length' osv_raw_report.json)
+          REPORT_RESULT_LENGTH=$(jq -r '.results[].package[] | length' osv_raw_report.json)
           echo "DEBUG: REPORT_RESULT_LENGTH=[$REPORT_RESULT_LENGTH]"
           if [ "$REPORT_RESULT_LENGTH" = "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"
-            SEVERITY_COUNTS="0 0 0"
+            SEVERITY_COUNTS="'0' '0' '0'"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
             SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,11 +265,11 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          REPORT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
+          REPORT_RESULT_LENGTH=$(jq -r '.results.packages[] | length' osv_raw_report.json)
           echo "DEBUG: REPORT_RESULT_LENGTH=[$REPORT_RESULT_LENGTH]"
           if [ "$REPORT_RESULT_LENGTH" = "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"
-            SEVERITY_COUNTS="'0' '0' '0'"
+            SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
             SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 
@@ -278,8 +278,8 @@ jobs:
                 | tonumber] 
               | [
                   (map(select(. < 4)) | length),
-                  (map(select(. >= 4 and . <= 6)) | length),
-                  (map(select(. > 6)) | length)
+                  (map(select(. >= 4 and . <= 7)) | length),
+                  (map(select(. > 7)) | length)
                 ] 
               | @sh
             ' osv_raw_report.json)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -275,7 +275,7 @@ jobs:
           fi
 
       - name: Comment Dependency scan report on PR
-        if: ${{ !cancelled() && contains('success,failure', steps.dependency_scan.outcome) }}
+        if: ${{ !cancelled() || contains('success,failure', steps.dependency_scan.outcome) }}
         uses: mshick/add-pr-comment@v2
         with:
           message-id: dependency_scan

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -122,7 +122,7 @@ jobs:
       security-events: write
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !contains(inputs.excluded_jobs, 'dependency_scan') }}
     container:
-      image: public.ecr.aws/studiographene/ci:node-22-alpine
+      image: public.ecr.aws/studiographene/ci:node-20-alpine
     steps:
       - name: Check for composer.lock or composer.json
         id: check_files

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           SEVERITY_COUNTS=$(jq -r '
-            if (.results | length) == 0 then
+            if (.results | length) == 0; then
               "0 0 0"
             else
               [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores |

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -285,12 +285,11 @@ jobs:
             echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW" >> osv_report.md
             echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM" >> osv_report.md
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH" >> osv_report.md
-            echo <br> >> osv_report.md
-            echo "### $OSV_SEVERITY_HIGH HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
-            cat osv_raw_report.md >> osv_report.md
+            echo "### ${OSV_SEVERITY_HIGH} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
             echo "LOW SEVERITY COUNT: $OSV_SEVERITY_LOW"
             echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM"
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH"
+            cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md
             cat osv_raw_report.md >> osv_report.md

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -260,13 +260,11 @@ jobs:
           osv-scanner --format json --config=./dep_scan_suppression_config.toml --sbom=bom.xml > osv_raw_report.json
           echo "OSV_EXIT_CODE=$?" >> $GITHUB_OUTPUT
           set -e
-
       - name: Generate Dependency Scan Report
         id: generate_dependency_scan_report
         env:
           OSV_EXIT_CODE: ${{ steps.dependency_scan.outputs.OSV_EXIT_CODE }}
         run: |
-          echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           if [ $OSV_EXIT_CODE -ne 0 ]; then
             echo "Executing IF statement (vulnerabilities found)"
             SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber ]
@@ -277,33 +275,30 @@ jobs:
                 ] 
               | @sh
             ' osv_raw_report.json)
-          fi
-          low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
-          medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)
-          high=$(echo $SEVERITY_COUNTS | cut -d' ' -f3)
-          echo "OSV_SEVERITY_LOW=$low" >> $GITHUB_OUTPUT
-          echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
-          echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT
-          echo "## OSV Dependency Scan Report" >> osv_report.md
-          if [ $OSV_EXIT_CODE -ne 0 ]; then
+            OSV_SEVERITY_LOW=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
+            OSV_SEVERITY_MEDIUM=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)
+            OSV_SEVERITY_HIGH=$(echo $SEVERITY_COUNTS | cut -d' ' -f3)
+            echo "OSV_SEVERITY_LOW=$low" >> $GITHUB_OUTPUT
+            echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
+            echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT
             echo "### The following vulnerabilities have been detected in the packages" >> osv_report.md
-            echo "$OSV_SEVERITY_HIGH HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:" >> osv_report.md
+            echo "$OSV_SEVERITY_HIGH HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
             echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW" >> osv_report.md
-            echo "> MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM" >> osv_report.md
-            echo "> HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH<br><br>" >> osv_report.md
+            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM" >> osv_report.md
+            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH" >> osv_report.md
+            echo "<br>" >> osv_report.md
+            echo "LOW SEVERITY COUNT: $OSV_SEVERITY_LOW"
+            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM"
+            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH"
             cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md
             cat osv_raw_report.md >> osv_report.md
           fi
-          if [ $OSV_SEVERITY_HIGH > 0 ]; then
-            echo "::error::HIGH SEVERITY Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
-            exit 1
-          elif [ $OSV_SEVERITY_HIGH == 0 && ($OSV_SEVERITY_LOW > 0 || $OSV_SEVERITY_MEDIUM > 0 )]; then
-            echo "::warning::MODERATE or LOW SEVERITY Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
-            exit 0
-          fi
-
+          echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW"
+          echo "> MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM"
+          echo "> HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH"
+          cat osv_report.md
       - name: Comment Dependency scan report on PR
         if: ${{ !cancelled() || contains('success,failure', steps.dependency_scan.outcome) }}
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -124,6 +124,10 @@ jobs:
     container:
       image: public.ecr.aws/studiographene/ci:node-20-alpine
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Check for composer.lock or composer.json
         id: check_files
         run: |

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -145,7 +145,11 @@ jobs:
         run: |
           cdxgen --version
           npm install -g @cyclonedx/cdxgen-plugins-bin
-          cdxgen --no-recurse -o bom.xml -p
+          # cdxgen --no-recurse -o bom.xml -p
+          ls -al
+          ls package.json
+          cdxgen --no-recurse -o bom.xml -p --debug
+          ls -al
         env:
           FETCH_LICENSE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -276,6 +276,7 @@ jobs:
                 ($scores | map(select(. >= 4 and . <= 6)) | length),
                 ($scores | map(select(. > 6)) | length)
               ] | @sh' osv_raw_report.json)
+            echo "Executing ELSE statement complete"
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
           medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -256,21 +256,47 @@ jobs:
           EOF
           set +e
           osv-scanner --format markdown --config=./dep_scan_suppression_config.toml --sbom=bom.xml > osv_raw_report.md
+          # JSON report is generated to segregate the vulnerabilities based on the CVSS score
           osv-scanner --format json --config=./dep_scan_suppression_config.toml --sbom=bom.xml > osv_raw_report.json
-          OSV_EXIT_CODE=$?
+          echo "OSV_EXIT_CODE=$?" >> $GITHUB_OUTPUT
           set -e
+
+      - name: Generate Dependency Scan Report
+        id: generate_dependency_scan_report
+        run: |
+          SEVERITY_COUNTS=$(jq -r '
+            if (.results | length) == 0 then
+              "0 0 0"
+            else
+              [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores |
+              [
+                ($scores | map(select(. < 4)) | length),
+                ($scores | map(select(. >= 4 and . <= 6)) | length),
+                ($scores | map(select(. > 6)) | length)
+              ] | @sh
+            end
+          ' osv_raw_report.json)
+          read low medium high <<< $SEVERITY_COUNTS
+          echo "OSV_SEVERITY_LOW=$low" >> $GITHUB_OUTPUT
+          echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
+          echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT
           echo "## OSV Dependency Scan Report" >> osv_report.md
           if [ $OSV_EXIT_CODE -ne 0 ]; then
-            echo "### The following vulnerabilities have been detected in the packages. Please resolve these before merging the pull request:" >> osv_report.md
+            echo "### The following vulnerabilities have been detected in the packages" >> osv_report.md
+            echo "$OSV_SEVERITY_HIGH HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:" >> osv_report.md
+            echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW" >> osv_report.md
+            echo "> MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM" >> osv_report.md
+            echo "> HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH<br><br>" >> osv_report.md
             cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md
             cat osv_raw_report.md >> osv_report.md
           fi
-          if [ $OSV_EXIT_CODE != 0 ]; then
-            echo "::error::Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
+          if [ $OSV_SEVERITY_HIGH > 0 ]; then
+            echo "::error::HIGH SEVERITY Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
             exit 1
-          elif [ $OSV_EXIT_CODE == 0 ]; then
+          elif [ $OSV_SEVERITY_HIGH == 0 && ($OSV_SEVERITY_LOW > 0 || $OSV_SEVERITY_MEDIUM > 0 )]; then
+            echo "::warning::MODERATE or LOW SEVERITY Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
             exit 0
           fi
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -250,7 +250,8 @@ jobs:
               ${{ vars.OSV_SUPPRESSIONS }}
           EOF
           set +e
-          osv-scanner --format markdown --config=./dep_scan_suppression_config.toml --sbom=bom.xml > osv_raw_report.md 
+          osv-scanner --format markdown --config=./dep_scan_suppression_config.toml --sbom=bom.xml > osv_raw_report.md
+          osv-scanner --format json --config=./dep_scan_suppression_config.toml --sbom=bom.xml > osv_raw_report.json
           OSV_EXIT_CODE=$?
           set -e
           echo "## OSV Dependency Scan Report" >> osv_report.md
@@ -274,3 +275,12 @@ jobs:
         with:
           message-id: dependency_scan
           message-path: osv_report.md
+      
+      - name: Upload Dependency scan JSON report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency_scan
+          path: |
+            osv_raw_report.json
+            osv_raw_report.md
+

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -122,7 +122,7 @@ jobs:
       security-events: write
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !contains(inputs.excluded_jobs, 'dependency_scan') }}
     container:
-      image: public.ecr.aws/studiographene/ci:node-20-alpine
+      image: public.ecr.aws/studiographene/ci:node-22-alpine
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,9 +149,6 @@ jobs:
         run: |
           cdxgen --version
           npm install -g @cyclonedx/cdxgen-plugins-bin
-          # cdxgen --no-recurse -o bom.xml -p
-          ls -al
-          ls package.json
           cdxgen --no-recurse -o bom.xml -p --debug
           ls -al
         env:

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -278,30 +278,21 @@ jobs:
             OSV_SEVERITY_LOW_COUNT=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
             OSV_SEVERITY_MEDIUM_COUNT=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)
             OSV_SEVERITY_HIGH_COUNT=$(echo $SEVERITY_COUNTS | cut -d' ' -f3)
-            echo "OSV_SEVERITY_LOW_COUNT=$low" >> $GITHUB_OUTPUT
-            echo "OSV_SEVERITY_MEDIUM_COUNT=$medium" >> $GITHUB_OUTPUT
-            echo "OSV_SEVERITY_HIGH_COUNT=$high" >> $GITHUB_OUTPUT
             echo "### The following vulnerabilities have been detected in the packages" >> osv_report.md
             echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT" >> osv_report.md
             echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT" >> osv_report.md
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT" >> osv_report.md
             echo "### ${OSV_SEVERITY_HIGH_COUNT} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
-            echo "LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT"
-            echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT"
-            echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT"
             cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md
             cat osv_raw_report.md >> osv_report.md
           fi
-          echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT"
-          echo "> MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT"
-          echo "> HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT"
           cat osv_report.md
-          if [ $OSV_SEVERITY_HIGH_COUNT > 0 ]; then
+          if [ $OSV_SEVERITY_HIGH_COUNT -gt 0 ]; then
             echo "::error::HIGH Severity Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
             exit 1
-          elif [ $OSV_SEVERITY_MEDIUM_COUNT > 0 ]; then
+          elif [ $OSV_SEVERITY_MEDIUM_COUNT -gt 0 ]; then
             echo "::warning::MEDIUM or LOW Severity Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
             exit 0
           fi

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -3,6 +3,11 @@ name: Security scans
 on:
   workflow_call:
     inputs:
+      job_runtime:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        request: false
+        default: "ubuntu-latest"
       excluded_jobs:
         type: string
         default: ""
@@ -19,7 +24,7 @@ on:
 jobs:
   SAST:
     name: sast
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
       issues: write
@@ -35,10 +40,10 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      # - name: SAST before step
-      #   if: ${{ inputs.security_scan_before_step_command != '' }}
-      #   run: |
-      #     ${{ inputs.security_scan_before_step_command}}
+      - name: SAST before step
+        if: ${{ inputs.security_scan_before_step_command != '' }}
+        run: |
+          ${{ inputs.security_scan_before_step_command}}
       - name: SAST Scan using Semgrep
         id: generate_sast_report
         run: |
@@ -85,7 +90,7 @@ jobs:
 
   gitleaks:
     name: gitleaks
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
       issues: write
@@ -113,7 +118,7 @@ jobs:
 
   generate_sbom:
     name: generate_sbom
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
       issues: write
@@ -164,7 +169,7 @@ jobs:
 
   license_scan:
     name: license_scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     needs: generate_sbom
     permissions:
       contents: read
@@ -223,7 +228,7 @@ jobs:
   dependency_scan:
     needs: generate_sbom
     name: dependency_scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -3,7 +3,7 @@ name: Security scans
 on:
   workflow_call:
     inputs:
-      job_runtime:
+      job_runner:
         description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
         type: string
         required: false
@@ -24,7 +24,7 @@ on:
 jobs:
   SAST:
     name: sast
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write
@@ -90,7 +90,7 @@ jobs:
 
   gitleaks:
     name: gitleaks
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write
@@ -118,7 +118,7 @@ jobs:
 
   generate_sbom:
     name: generate_sbom
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write
@@ -169,7 +169,7 @@ jobs:
 
   license_scan:
     name: license_scan
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     needs: generate_sbom
     permissions:
       contents: read
@@ -228,7 +228,7 @@ jobs:
   dependency_scan:
     needs: generate_sbom
     name: dependency_scan
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -263,14 +263,13 @@ jobs:
 
       - name: Generate Dependency Scan Report
         id: generate_dependency_scan_report
+        env:
+          OSV_EXIT_CODE: ${{ steps.dependency_scan.outputs.OSV_EXIT_CODE }}
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          if [ "$OSV_EXIT_CODE" = "1" ]; then
+          if [ $OSV_EXIT_CODE -ne 0 ]; then
             echo "Executing IF statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 
-                | select(.groups != null) 
-                | .groups[]?.max_severity 
-                | tonumber] 
+            SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber ]
               | [
                   (map(select(. < 4)) | length),
                   (map(select(. >= 4 and . <= 7)) | length),

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -282,6 +282,7 @@ jobs:
           message-path: osv_report.md
       
       - name: Upload Dependency scan JSON report artifact
+        if: ${{ !cancelled() || contains('success,failure', steps.dependency_scan.outcome) }}
         uses: actions/upload-artifact@v4
         with:
           name: dependency_scan

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -285,7 +285,7 @@ jobs:
             if [ $OSV_SEVERITY_HIGH_COUNT -gt 0 ]; then
               echo "### ${OSV_SEVERITY_HIGH_COUNT} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
             else
-              echo "### LOW or MEDIUM SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
+              echo "### MEDIUM or LOW SEVERITY Packaged found:<br>" >> osv_report.md
             fi
             cat osv_raw_report.md >> osv_report.md
           else

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -264,6 +264,7 @@ jobs:
       - name: Generate Dependency Scan Report
         id: generate_dependency_scan_report
         run: |
+          echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           SEVERITY_COUNTS=$(jq -r '
             if (.results | length) == 0 then
               "0 0 0"
@@ -276,7 +277,9 @@ jobs:
               ] | @sh
             end
           ' osv_raw_report.json)
-          read low medium high <<< $SEVERITY_COUNTS
+          low=$(echo $count_output | cut -d' ' -f1)
+          medium=$(echo $count_output | cut -d' ' -f2)
+          high=$(echo $count_output | cut -d' ' -f3)
           echo "OSV_SEVERITY_LOW=$low" >> $GITHUB_OUTPUT
           echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
           echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,12 +271,12 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores 
-              | [
-                  ($scores | map(select(. < 4)) | length),
-                  ($scores | map(select(. >= 4 and . <= 6)) | length),
-                  ($scores | map(select(. > 6)) | length)
-                ] 
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores \
+              | [ \
+                  ($scores | map(select(. < 4)) | length), \
+                  ($scores | map(select(. >= 4 and . <= 6)) | length), \
+                  ($scores | map(select(. > 6)) | length) \
+                ] \
               | @sh' osv_raw_report.json)
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,7 +265,7 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          REPORT_RESULT_LENGTH=$(jq -r '.results.packages[] | length' osv_raw_report.json)
+          REPORT_RESULT_LENGTH=$(jq -r '.results[].package | length' osv_raw_report.json)
           echo "DEBUG: REPORT_RESULT_LENGTH=[$REPORT_RESULT_LENGTH]"
           if [ "$REPORT_RESULT_LENGTH" = "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,13 +271,16 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity  | tonumber] as $scores
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? 
+              | select(.groups != null) 
+              | .groups[]?.max_severity 
+              | tonumber] as $scores 
               | [
                   ($scores | map(select(. < 4)) | length),
                   ($scores | map(select(. >= 4 and . <= 6)) | length),
                   ($scores | map(select(. > 6)) | length)
-                ] | @sh' osv_raw_report.json)
-            echo "Executing ELSE statement complete"
+                ] 
+              | @sh' osv_raw_report.json)
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
           medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -266,6 +266,7 @@ jobs:
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           REPORT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
+          echo "DEBUG: REPORT_RESULT_LENGTH=[$REPORT_RESULT_LENGTH]"
           if [ "$REPORT_RESULT_LENGTH" = "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"
             SEVERITY_COUNTS="'0' '0' '0'"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,16 +271,17 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? \
-              | select(.groups != null) \
-              | .groups[]?.max_severity \
-              | tonumber] \
-              | [ \
-                  (map(select(. < 4)) | length), \
-                  (map(select(. >= 4 and . <= 6)) | length), \
-                  (map(select(. > 6)) | length) \
-                ] \
-              | @sh' osv_raw_report.json)
+            SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 
+                | select(.groups != null) 
+                | .groups[]?.max_severity 
+                | tonumber] 
+              | [
+                  (map(select(. < 4)) | length),
+                  (map(select(. >= 4 and . <= 6)) | length),
+                  (map(select(. > 6)) | length)
+                ] 
+              | @sh
+            ' osv_raw_report.json)
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
           medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -177,7 +177,7 @@ jobs:
       discussions: write
       pull-requests: write
       security-events: write
-    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !contains(inputs.excluded_jobs, 'dependency_scan') }}
+    if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') && !contains(inputs.excluded_jobs, 'license_scan') }}
     container:
       image: public.ecr.aws/studiographene/ci:node-22-alpine
     steps:

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,8 +271,8 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores \
-              | [ \
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores | \
+                [ \
                   ($scores | map(select(. < 4)) | length), \
                   ($scores | map(select(. >= 4 and . <= 6)) | length), \
                   ($scores | map(select(. > 6)) | length) \

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,11 +271,12 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity  | tonumber] as $scores | [
-                ($scores | map(select(. < 4)) | length),
-                ($scores | map(select(. >= 4 and . <= 6)) | length),
-                ($scores | map(select(. > 6)) | length)
-              ] | @sh' osv_raw_report.json)
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity  | tonumber] as $scores
+              | [
+                  ($scores | map(select(. < 4)) | length),
+                  ($scores | map(select(. >= 4 and . <= 6)) | length),
+                  ($scores | map(select(. > 6)) | length)
+                ] | @sh' osv_raw_report.json)
             echo "Executing ELSE statement complete"
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -6,7 +6,7 @@ on:
       job_runtime:
         description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
         type: string
-        request: false
+        required: false
         default: "ubuntu-latest"
       excluded_jobs:
         type: string

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           SEVERITY_COUNTS=$(jq -r '
-            if (.results | length) == 0; then
+            if [ (.results | length) == 0 ]; then
               "0 0 0"
             else
               [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores |

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -268,19 +268,14 @@ jobs:
           REPOSRT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
           if [ "$REPORT_RESULT_LENGTH" == "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"
-            SEVERITY_COUNTS="'0' '0' '0'"
+            SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? 
-              | select(.groups != null) 
-              | .groups[]?.max_severity 
-              | tonumber] as $scores 
-              | [
-                  ($scores | map(select(. < 4)) | length),
-                  ($scores | map(select(. >= 4 and . <= 6)) | length),
-                  ($scores | map(select(. > 6)) | length)
-                ] 
-              | @sh' osv_raw_report.json)
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity  | tonumber] as $scores | [
+                ($scores | map(select(. < 4)) | length),
+                ($scores | map(select(. >= 4 and . <= 6)) | length),
+                ($scores | map(select(. > 6)) | length)
+              ] | @sh' osv_raw_report.json)
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
           medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,7 +265,7 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          REPOSRT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
+          REPORT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
           if [ "$REPORT_RESULT_LENGTH" == "0" ]; then
             echo "Executing IF statement (no vulnerabilities found)"
             SEVERITY_COUNTS="0 0 0"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -271,11 +271,14 @@ jobs:
             SEVERITY_COUNTS="0 0 0"
           else
             echo "Executing ELSE statement (vulnerabilities found)"
-            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores | \
-                [ \
-                  ($scores | map(select(. < 4)) | length), \
-                  ($scores | map(select(. >= 4 and . <= 6)) | length), \
-                  ($scores | map(select(. > 6)) | length) \
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? \
+              | select(.groups != null) \
+              | .groups[]?.max_severity \
+              | tonumber] \
+              | [ \
+                  (map(select(. < 4)) | length), \
+                  (map(select(. >= 4 and . <= 6)) | length), \
+                  (map(select(. > 6)) | length) \
                 ] \
               | @sh' osv_raw_report.json)
           fi

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,18 +265,17 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          SEVERITY_COUNTS=$(jq -r '
-            if [ (.results | length) == 0 ]; then
-              "0 0 0"
-            else
-              [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores |
-              [
-                ($scores | map(select(. < 4)) | length),
-                ($scores | map(select(. >= 4 and . <= 6)) | length),
-                ($scores | map(select(. > 6)) | length)
-              ] | @sh
-            end
-          ' osv_raw_report.json)
+          REPOSRT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
+          if [ $REPOSRT_RESULT_LENGTH == 0 ]; then
+            SEVERITY_COUNTS="[0 0 0]"
+          else
+            SEVERITY_COUNTS=$(jq -r [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores |
+            [
+              ($scores | map(select(. < 4)) | length),
+              ($scores | map(select(. >= 4 and . <= 6)) | length),
+              ($scores | map(select(. > 6)) | length)
+            ] | @sh' data.json)
+          fi
           low=$(echo $count_output | cut -d' ' -f1)
           medium=$(echo $count_output | cut -d' ' -f2)
           high=$(echo $count_output | cut -d' ' -f3)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -280,7 +280,7 @@ jobs:
                   ($scores | map(select(. >= 4 and . <= 6)) | length),
                   ($scores | map(select(. > 6)) | length)
                 ] 
-              | @sh' test.json)
+              | @sh' osv_raw_report.json)
           fi
           low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
           medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -282,15 +282,15 @@ jobs:
             echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
             echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT
             echo "### The following vulnerabilities have been detected in the packages" >> osv_report.md
-            echo "$OSV_SEVERITY_HIGH HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
             echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW" >> osv_report.md
             echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM" >> osv_report.md
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH" >> osv_report.md
-            echo "<br>" >> osv_report.md
+            echo <br> >> osv_report.md
+            echo "### $OSV_SEVERITY_HIGH HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
+            cat osv_raw_report.md >> osv_report.md
             echo "LOW SEVERITY COUNT: $OSV_SEVERITY_LOW"
             echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM"
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH"
-            cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md
             cat osv_raw_report.md >> osv_report.md

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -284,6 +284,8 @@ jobs:
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT" >> osv_report.md
             if [ $OSV_SEVERITY_HIGH_COUNT -gt 0 ]; then
               echo "### ${OSV_SEVERITY_HIGH_COUNT} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
+            else
+              echo "### LOW or MEDIUM SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
             fi
             cat osv_raw_report.md >> osv_report.md
           else

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -266,19 +266,25 @@ jobs:
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
           REPOSRT_RESULT_LENGTH=$(jq -r '.results | length' osv_raw_report.json)
-          if [ $REPOSRT_RESULT_LENGTH == 0 ]; then
-            SEVERITY_COUNTS="[0 0 0]"
+          if [ "$REPORT_RESULT_LENGTH" == "0" ]; then
+            echo "Executing IF statement (no vulnerabilities found)"
+            SEVERITY_COUNTS="'0' '0' '0'"
           else
-            SEVERITY_COUNTS=$(jq -r [.results[].packages[]? | select(.groups != null) | .groups[]?.max_severity | tonumber] as $scores |
-            [
-              ($scores | map(select(. < 4)) | length),
-              ($scores | map(select(. >= 4 and . <= 6)) | length),
-              ($scores | map(select(. > 6)) | length)
-            ] | @sh' data.json)
+            echo "Executing ELSE statement (vulnerabilities found)"
+            SEVERITY_COUNTS=$(jq -r '[.results[].packages[]? 
+              | select(.groups != null) 
+              | .groups[]?.max_severity 
+              | tonumber] as $scores 
+              | [
+                  ($scores | map(select(. < 4)) | length),
+                  ($scores | map(select(. >= 4 and . <= 6)) | length),
+                  ($scores | map(select(. > 6)) | length)
+                ] 
+              | @sh' test.json)
           fi
-          low=$(echo $count_output | cut -d' ' -f1)
-          medium=$(echo $count_output | cut -d' ' -f2)
-          high=$(echo $count_output | cut -d' ' -f3)
+          low=$(echo $SEVERITY_COUNTS | cut -d' ' -f1)
+          medium=$(echo $SEVERITY_COUNTS | cut -d' ' -f2)
+          high=$(echo $SEVERITY_COUNTS | cut -d' ' -f3)
           echo "OSV_SEVERITY_LOW=$low" >> $GITHUB_OUTPUT
           echo "OSV_SEVERITY_MEDIUM=$medium" >> $GITHUB_OUTPUT
           echo "OSV_SEVERITY_HIGH=$high" >> $GITHUB_OUTPUT

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -265,13 +265,8 @@ jobs:
         id: generate_dependency_scan_report
         run: |
           echo "Parsing the Dependency Scan Report for vulnerability segregation based on score..."
-          REPORT_RESULT_LENGTH=$(jq -r '.results[].package[] | length' osv_raw_report.json)
-          echo "DEBUG: REPORT_RESULT_LENGTH=[$REPORT_RESULT_LENGTH]"
-          if [ "$REPORT_RESULT_LENGTH" = "0" ]; then
-            echo "Executing IF statement (no vulnerabilities found)"
-            SEVERITY_COUNTS="'0' '0' '0'"
-          else
-            echo "Executing ELSE statement (vulnerabilities found)"
+          if [ "$OSV_EXIT_CODE" == 1 ]; then
+            echo "Executing IF statement (vulnerabilities found)"
             SEVERITY_COUNTS=$(jq -r ' [.results[].packages[]? 
                 | select(.groups != null) 
                 | .groups[]?.max_severity 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -282,7 +282,9 @@ jobs:
             echo "> LOW SEVERITY COUNT: $OSV_SEVERITY_LOW_COUNT" >> osv_report.md
             echo "MEDIUM SEVERITY COUNT: $OSV_SEVERITY_MEDIUM_COUNT" >> osv_report.md
             echo "HIGH SEVERITY COUNT: $OSV_SEVERITY_HIGH_COUNT" >> osv_report.md
-            echo "### ${OSV_SEVERITY_HIGH_COUNT} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
+            if [ $OSV_SEVERITY_HIGH_COUNT -gt 0 ]; then
+              echo "### ${OSV_SEVERITY_HIGH_COUNT} HIGH SEVERITY Packaged found. Please resolve these before merging the pull request:<br>" >> osv_report.md
+            fi
             cat osv_raw_report.md >> osv_report.md
           else
             echo "### :tada:! There are no vulnerabilities found in the packages." >> osv_report.md

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -10,7 +10,7 @@ on:
       job_runtime:
         description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
         type: string
-        request: false
+        required: false
         default: "ubuntu-latest"
       action_runner_container_image:
         description: "Action runner container image. Default = public.ecr.aws/studiographene/ci:node-20-alpine"

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -176,7 +176,7 @@ jobs:
           echo "$matrix_json" >> "$GITHUB_OUTPUT"
           echo "EOF" >> $GITHUB_OUTPUT
           echo $matrix_json
-          echo "$GITHUB_OUTPUT"
+          echo "$matrix_json"
 
 
   containers_scan:

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -7,7 +7,7 @@ on:
         required: false
 
     inputs:
-      job_runtime:
+      job_runner:
         description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
         type: string
         required: false
@@ -62,7 +62,7 @@ permissions:
 
 jobs:
   container_scan_single:
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     if: ${{ !inputs.is_monorepo_with_multi_dockerfile }}
     container:
       image: ${{ inputs.action_runner_container_image }}
@@ -151,7 +151,7 @@ jobs:
           ${{ inputs.after_step_command}}
 
   detect_dockerfile_paths:
-    runs-on: ${{ inputs.job_runtime }}
+    runs-on: ${{ inputs.job_runner }}
     if: ${{ inputs.is_monorepo_with_multi_dockerfile }}
     name: Detect Dockerfile Paths
     outputs:
@@ -185,7 +185,7 @@ jobs:
 
 
   containers_scan:
-      runs-on: ${{ inputs.job_runtime }}
+      runs-on: ${{ inputs.job_runner }}
       if: ${{ inputs.is_monorepo_with_multi_dockerfile }}
       needs: detect_dockerfile_paths
       container:

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -257,7 +257,7 @@ jobs:
             echo "# Trivy Container Scan" > container_scan_prcomment.json
             if [ ${{ steps.container_scan.outcome }} == "failure" ]
             then
-              echo "### :warning: Vulnerabilities detected Dockerfile: ${{ matrix.dockerfile_paths }} The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
+              echo "### :warning: Vulnerabilities detected Dockerfile: ${{ matrix.dockerfile_paths }}<br>The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
               cat trivyreport.json >> container_scan_prcomment.json
               echo "::error::Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
               exit 1

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -16,11 +16,6 @@ on:
         description: "Action runner container image. Default = public.ecr.aws/studiographene/ci:node-20-alpine"
         type: string
         default: public.ecr.aws/studiographene/ci:node-20-alpine
-      is_monorepo_with_multi_dockerfile:
-        description: "Whether it is a monorepo with Dockerfile in differnet directories. If `true` repo will be searched for all the Dockerfile and scan performed on each. To scan only selected Docker file use input `dockerfile_paths`"
-        type: boolean
-        required: false
-        default: false
       dockerfile_paths:
         description: "Set of separated Dockerfile paths. Useful when you want scan Dockerfile in selected directories. Example: [./apps/users/Dockerfile, ./apps/account/Dockerfile]"
         type: string
@@ -61,98 +56,8 @@ permissions:
   contents: read
 
 jobs:
-  container_scan_single:
-    runs-on: ${{ inputs.job_runner }}
-    if: ${{ !inputs.is_monorepo_with_multi_dockerfile }}
-    container:
-      image: ${{ inputs.action_runner_container_image }}
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Before Step
-        if: ${{ inputs.before_step_command != '' }}
-        run: |
-          ${{ inputs.before_step_command}}
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker Build
-        id: docker_build
-        env:
-          FINAL_DOCKER_BUILD_COMMAND: ${{ inputs.docker_build_command != '' && inputs.docker_build_command || format('docker build --build-arg NPM_TOKEN={0} -t  {1} .', secrets.NPM_TOKEN, inputs.docker_build_image_id) }}
-        run: |
-          echo $FINAL_DOCKER_BUILD_COMMAND
-          eval $FINAL_DOCKER_BUILD_COMMAND
-
-      - name: Creating Trivy report PR comment template file
-        run: |
-          cat <<EOF >> trivyreport.tpl 
-          | Package | Vulnerability | Severity | Status | Installed Version | Fixed Version | Title |
-          | ------- | ------------- | -------- | ------ | ----------------- | ------------- | ----- |
-          {{- range .}}
-          {{- range .Vulnerabilities}}
-          | {{ .PkgName | html }} | {{ .VulnerabilityID | html }} | {{ .Severity | html }} | {{ .Status | html }} | {{ .InstalledVersion | html }} | {{ .FixedVersion | html }} | {{ .Title | html }} |
-          {{- end }}
-          {{- end }}
-          EOF
-
-      - name: Trivy container vulnerability scan
-        id: container_scan
-        uses: aquasecurity/trivy-action@master
-        continue-on-error: true
-        with:
-          image-ref: ${{ inputs.docker_build_image_id }}
-          format: "template"
-          template: "@trivyreport.tpl"
-          output: "trivyreport.json"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
-          scanners: ${{ inputs.container_scanners }}
-          skip-dirs: ${{ inputs.container_scan_skip_dirs }}
-
-      - name: Create container vulnerability report
-        if: ${{ !cancelled()  }}
-        shell: bash
-        run: |
-          echo "# Trivy Container Scan" > container_scan_prcomment.json
-          if [ ${{ steps.container_scan.outcome }} == "failure" ]
-          then
-            echo "### :warning: Vulnerabilities detected<br>The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
-            cat trivyreport.json >> container_scan_prcomment.json
-            echo "::error::Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
-            exit 1
-          elif [ ${{ steps.container_scan.outcome }} == "success" ]
-          then
-            echo "### :rainbow: No vulnerabilities of HIGH or CRITICAL severity detected" >> container_scan_prcomment.json
-            exit 0
-          fi
-
-      - name: PR comment the container scan report
-        uses: mshick/add-pr-comment@v2
-        with:
-          message-id: trivy_container_scan
-          message-path: container_scan_prcomment.json
-
-      - name: After Step
-        if: ${{ inputs.after_step_command != '' }}
-        run: |
-          ${{ inputs.after_step_command}}
-
   detect_dockerfile_paths:
     runs-on: ${{ inputs.job_runner }}
-    if: ${{ inputs.is_monorepo_with_multi_dockerfile }}
     name: Detect Dockerfile Paths
     outputs:
       matrix: ${{ inputs.dockerfile_paths == '' && steps.find_dockerfile_generate_matrix.outputs.all_dockerfile_paths_matrix || steps.generate_matrix.outputs.all_dockerfile_paths_matrix }}
@@ -186,7 +91,6 @@ jobs:
 
   containers_scan:
       runs-on: ${{ inputs.job_runner }}
-      if: ${{ inputs.is_monorepo_with_multi_dockerfile }}
       needs: detect_dockerfile_paths
       container:
         image: ${{ inputs.action_runner_container_image }}
@@ -257,13 +161,13 @@ jobs:
             echo "# Trivy Container Scan" > container_scan_prcomment.json
             if [ ${{ steps.container_scan.outcome }} == "failure" ]
             then
-              echo "### :warning: Vulnerabilities detected Dockerfile: ${{ matrix.dockerfile_paths }}<br>The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
+              echo "### :warning: Vulnerabilities detected Dockerfile path ${{ matrix.dockerfile_paths }}:<br>The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
               cat trivyreport.json >> container_scan_prcomment.json
               echo "::error::Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
               exit 1
             elif [ ${{ steps.container_scan.outcome }} == "success" ]
             then
-              echo "### :rainbow: Dockerfile: ${{ matrix.dockerfile_paths }} No vulnerabilities of HIGH or CRITICAL severity detected" >> container_scan_prcomment.json
+              echo "### :rainbow: Dockerfile path ${{ matrix.dockerfile_paths }}: No vulnerabilities of HIGH or CRITICAL severity detected" >> container_scan_prcomment.json
               exit 0
             fi
 

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -250,6 +250,7 @@ jobs:
             skip-dirs: ${{ inputs.container_scan_skip_dirs }}
 
         - name: Create container vulnerability report
+          id: container_scan_report_generation
           if: ${{ !cancelled()  }}
           shell: bash
           run: |
@@ -267,7 +268,7 @@ jobs:
             fi
 
         - name: PR comment the container scan report
-          if: ${{ !cancelled()  }}
+          if: ${{ !cancelled() && contains('success,failure', steps.container_scan_report_generation.outcome) }}
           uses: mshick/add-pr-comment@v2
           with:
             message-id: trivy_container_scan_${{ matrix.dockerfile_paths }}

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -161,13 +161,13 @@ jobs:
             echo "# Trivy Container Scan" > container_scan_prcomment.json
             if [ ${{ steps.container_scan.outcome }} == "failure" ]
             then
-              echo "### :warning: Vulnerabilities detected Dockerfile path ${{ matrix.dockerfile_paths }}:<br>The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
+              echo "### :warning: Vulnerabilities detected Dockerfile path \[ ${{ matrix.dockerfile_paths }} \]:<br>The following vulnerabilities of HIGH or CRITICAL severity has been detected in the code. Please resolve these before merging the pull request.<br><br>" >> container_scan_prcomment.json
               cat trivyreport.json >> container_scan_prcomment.json
               echo "::error::Vulnerabilities found! Find the scan report in the PR comment if this scan was triggered by PR"
               exit 1
             elif [ ${{ steps.container_scan.outcome }} == "success" ]
             then
-              echo "### :rainbow: Dockerfile path ${{ matrix.dockerfile_paths }}: No vulnerabilities of HIGH or CRITICAL severity detected" >> container_scan_prcomment.json
+              echo "### :rainbow: Dockerfile path \[ ${{ matrix.dockerfile_paths }} \]: No vulnerabilities of HIGH or CRITICAL severity detected" >> container_scan_prcomment.json
               exit 0
             fi
 

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -7,6 +7,11 @@ on:
         required: false
 
     inputs:
+      job_runtime:
+        description: "GitHub action Jobs runtime. For example GitHub default runtimes like ubuntu-latest or you custome runtime. Default = ubuntu-latest"
+        type: string
+        request: false
+        default: "ubuntu-latest"
       action_runner_container_image:
         description: "Action runner container image. Default = public.ecr.aws/studiographene/ci:node-20-alpine"
         type: string
@@ -57,7 +62,7 @@ permissions:
 
 jobs:
   container_scan_single:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     if: ${{ !inputs.is_monorepo_with_multi_dockerfile }}
     container:
       image: ${{ inputs.action_runner_container_image }}
@@ -146,7 +151,7 @@ jobs:
           ${{ inputs.after_step_command}}
 
   detect_dockerfile_paths:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.job_runtime }}
     if: ${{ inputs.is_monorepo_with_multi_dockerfile }}
     name: Detect Dockerfile Paths
     outputs:
@@ -180,7 +185,7 @@ jobs:
 
 
   containers_scan:
-      runs-on: ubuntu-latest
+      runs-on: ${{ inputs.job_runtime }}
       if: ${{ inputs.is_monorepo_with_multi_dockerfile }}
       needs: detect_dockerfile_paths
       container:
@@ -262,12 +267,13 @@ jobs:
             fi
 
         - name: PR comment the container scan report
+          if: ${{ !cancelled()  }}
           uses: mshick/add-pr-comment@v2
           with:
             message-id: trivy_container_scan_${{ matrix.dockerfile_paths }}
             message-path: container_scan_prcomment.json
 
         - name: After Step
-          if: ${{ inputs.after_step_command != '' }}
+          if: ${{ inputs.after_step_command != '' && !cancelled() }}
           run: |
             ${{ inputs.after_step_command}}

--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -268,7 +268,7 @@ jobs:
             fi
 
         - name: PR comment the container scan report
-          if: ${{ !cancelled() && contains('success,failure', steps.container_scan_report_generation.outcome) }}
+          if: ${{ !cancelled() || contains('success,failure', steps.container_scan_report_generation.outcome) }}
           uses: mshick/add-pr-comment@v2
           with:
             message-id: trivy_container_scan_${{ matrix.dockerfile_paths }}

--- a/README-nodejs-ci.md
+++ b/README-nodejs-ci.md
@@ -99,28 +99,6 @@ jobs:
     secrets: inherit
 ```
 
-
-#### ci.yml (for Monorepo with multiple Dockerfiles to scan every Dockerfile in the repo)
-
-```yaml
-name: CI
-
-on:
-  pull_request: {}
-  issue_comment:
-
-jobs:
-  call-workflow:
-    uses: studiographene/github-action-workflows/.github/workflows/nodejs-ci.yml@master # if you want alternatively pin to tag version
-    with:
-      package_manager: pnpm
-      build_command: pnpm run build
-      lint_command: pnpm run lint
-      run_dev_test: true   # Set this input only if the Developer tests (Unit/Integration/etc.,) are available in your repo code
-      is_monorepo_with_multi_dockerfile: true
-    secrets: inherit
-```
-
 ---
 
 ### Jobs list:

--- a/README-nodejs-ci.md
+++ b/README-nodejs-ci.md
@@ -15,8 +15,11 @@ CI scans workflow for NodeJS code.
 | coverage_summary_path | Path to the coverage summary JSON file generated from developer's test | no | `./coverage/coverage-summary.json` |
 | junitxml_path  | Path to the JUnit XML report file generated from developer's test | no | `./coverage/report.xml`  |                                                                             | no       | `npm`           |
 | build_command                              | build command for the project                                               | no       | `npm run build` |
+| package_install_command                    | Package install command to use instead of the default command               | no       |                 |
 | docker_build_command                       | Docker build command                                                        | no       |                 |
 | docker_build_image_id                      | Docker image ID as mentioned in docker_build_command                        | no       | `local:latest`  |
+| is_monorepo_with_multi_dockerfile          | For container scan. Whether it is a monorepo with Dockerfile in differnet directories. If `true` repo will be searched for all the Dockerfile and scan performed on each. To scan only selected Docker file use input `dockerfile_paths` | no  | false  |
+|       dockerfile_paths:                    | For container scan. Set of separated Dockerfile paths. Useful when you want scan Dockerfile in selected directories. Example: [./apps/users/Dockerfile, ./apps/account/Dockerfile] | no  |   |
 | container_scanners:                        | comma-separated list of what security issues to detect (vuln,secret,config) | no       | `vuln`          |
 | container_scan_skip_dirs                   | Comma separated list of directories to skip scanning                        | no       |                 |
 | lint_command                               | lint command for the project                                                | no       | `npm run lint`  |
@@ -65,7 +68,7 @@ CI scans workflow for NodeJS code.
 
 ### CI workflow
 
-1. Create a file `ci.yml` with below content (change inputs as required).
+In your repo, create a file `ci.yml` under `.github/workflows` folder with below content _(change inputs as required)_.
 
 #### ci.yml
 
@@ -87,6 +90,28 @@ jobs:
     secrets: inherit
 ```
 
+
+#### ci.yml (for Monorepo with multiple Dockerfiles to scan every Dockerfile in the repo)
+
+```yaml
+name: CI
+
+on:
+  pull_request: {}
+  issue_comment:
+
+jobs:
+  call-workflow:
+    uses: studiographene/github-action-workflows/.github/workflows/nodejs-ci.yml@master # if you want alternatively pin to tag version
+    with:
+      package_manager: pnpm
+      build_command: pnpm run build
+      lint_command: pnpm run lint
+      run_dev_test: true   # Set this input only if the Developer tests (Unit/Integration/etc.,) are available in your repo code
+      is_monorepo_with_multi_dockerfile: true
+    secrets: inherit
+```
+
 ---
 
 ### Jobs list:
@@ -94,7 +119,7 @@ jobs:
 #### Jobs have nested steps which are running the mentioned scans.
 
 - pr_agent (Automated PR review using [Codium AI PR Agent](https://www.codium.ai/products/git-plugin/) )
-- docker
+- Container scan
   - docker build
   - container scan (using [Trivy](https://github.com/aquasecurity/trivy))
 - Security scans
@@ -105,3 +130,4 @@ jobs:
 - Technology based scans
   - lint
   - build (code build check)
+- Pulse Work Breakdown

--- a/README-nodejs-ci.md
+++ b/README-nodejs-ci.md
@@ -28,14 +28,23 @@ CI scans workflow for NodeJS code.
 | security_scan_after_step_command           | Optional commands to pass after secuirty scan job steps execution           | no       |                 |
 | caching_before_step_command                | Optional commands to pass before caching job steps execution                | no       |                 |
 | caching_after_step_command                 | Optional commands to pass after caching job steps execution                 | no       |                 |
-| technology_based_scans_before_step_command | Optional commands to pass before techology based scans job steps execution  | no       |                 |
-| technology_based_scans_after_step_command  | Optional commands to pass after techology based scans job steps execution   | no       |                 |
 | pr_agent_before_step_command               | Optional commands to pass before Codium PR agent job steps execution        | no       |                 |
 | pr_agent_after_step_command                | Optional commands to pass after Codium PR agent job steps execution         | no       |                 |
 | container_scan_before_step_command         | Command to execute at the start of the container scan                       | no       |                 |
 | container_scan_after_step_command          | Command to execute at the end of the container scan                         | no       |                 |
+| developer_tests_before_step_command        | Command to execute at the start of the Developer tests                      | no       |                 |
+| developer_tests_after_step_command         | Command to execute at the end of the Developer tests                        | no       |                 |
+| lint_scan_before_step_command              | Command to execute at the start of the Lint scan                            | no       |                 |
+| lint_scan_after_step_command               | Command to execute at the end of the Lint scan                              | no       |                 |
 | send_dev_test_coverage_report_to_pulse     | Switch deciding to send the Test Coverage Report to Pulse                   | no       | false           |
 | dev_test_coverage_report_directory         | The Directory path from project root where `coverage-summary.json` is generated after running test | false  | `coverage`  |
+
+# Depreciated Inputs
+
+| Name                                       | Description                                                                                                       | Required | Default  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| technology_based_scans_before_step_command | *DEPRECIATED:* only kept to tackle the backwards compatibility to avoid error use the respective new job inputs   |    no    |          |
+| technology_based_scans_after_step_command  | *DEPRECIATED:* only kept to tackle the backwards compatibility to avoid error use the respective new job inputs   |    no    |          |
 
 # Workflow Secrets
 

--- a/README-php-ci.md
+++ b/README-php-ci.md
@@ -9,6 +9,8 @@ CI scans workflow for PhP code.
 | Name                                              | Description                                                                                                                                                                         | Required | Default        |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- |
 | excluded_jobs <a name="inputs_EXCLUDED_JOBS"></a> | A string of comma separated job IDs that you want to exclude from execution. Job IDs that can be used to exclude `lint,sast,gitleaks,license_scan,dependency_scan,docker,pr_agent`. | no       |                |
+| is_monorepo_with_multi_dockerfile          | For container scan. Whether it is a monorepo with Dockerfile in differnet directories. If `true` repo will be searched for all the Dockerfile and scan performed on each. To scan only selected Docker file use input `dockerfile_paths` | no  | false  |
+|       dockerfile_paths:                    | For container scan. Set of separated Dockerfile paths. Useful when you want scan Dockerfile in selected directories. Example: [./apps/users/Dockerfile, ./apps/account/Dockerfile] | no  |   |
 | docker_build_command                              | Docker build command                                                                                                                                                                | no       |                |
 | docker_build_image_id                             | Docker image ID as mentioned in docker_build_command                                                                                                                                | no       | `local:latest` |
 | container_scanners:                               | comma-separated list of what security issues to detect (vuln,secret,config)                                                                                                         | no       | `vuln`         |
@@ -52,7 +54,28 @@ on:
 
 jobs:
   call-workflow:
-    uses: studiographene/github-action-workflows/.github/workflows/php-ci.yml@master # if you want alternatively pin to tag version version
+    uses: studiographene/github-action-workflows/.github/workflows/php-ci.yml@master # if you want alternatively pin to tag version
+    secrets: inherit
+```
+
+#### ci.yml (for Monorepo with multiple Dockerfiles to scan every Dockerfile in the repo)
+
+```yaml
+name: CI
+
+on:
+  pull_request: {}
+  issue_comment:
+
+jobs:
+  call-workflow:
+    uses: studiographene/github-action-workflows/.github/workflows/nodejs-ci.yml@master # if you want alternatively pin to tag version
+    with:
+      package_manager: pnpm
+      build_command: pnpm run build
+      lint_command: pnpm run lint
+      run_dev_test: true   # Set this input only if the Developer tests (Unit/Integration/etc.,) are available in your repo code
+      is_monorepo_with_multi_dockerfile: true
     secrets: inherit
 ```
 


### PR DESCRIPTION
- Steps from security-scan, technology base scan are made into separate jobs
- Container scan now automatically detects all the Dockerfile in the repo and runs scan for each Dockerfile
- Dependency scan fails moderately only when high severity vulnerability of CVSS > 7 is found
- PR agent removed in favor of copilot in GitHub.

## Issue ticket number and link

- ENB-83

## Type of change

Please check the relevant option.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Tested the changed workflows in a repo

## Checklist:

- [ ] I have reviewed my code while raising this PR
- [ ] I have added comments to my code, particularly in hard-to-understand areas
- [ ] I have created a new README file named as `README-<name-of-the-workflow-file>.md` in case of new workflow addition, or made corresponding changes to the documentation with respect to the changes.
- [ ] My changes generate no new warnings and errors
